### PR TITLE
Agregar soporte para Shared Preferences en el servicio de anuncios

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import firebase_storage
 import google_sign_in_ios
 import local_auth_darwin
 import path_provider_foundation
+import shared_preferences_foundation
 import sign_in_with_apple
 import url_launcher_macos
 import webview_flutter_wkwebview
@@ -30,6 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
  #admob
   google_mobile_ads: ^5.3.1
+  #shared preferences
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Incluir la dependencia de shared_preferences en pubspec.yaml
- Implementar inicialización y manejo de Shared Preferences en AdService
- Añadir lógica para determinar si se debe mostrar un anuncio basado en el tiempo desde el último cierre
- Marcar anuncios como cerrados y registrar el tiempo de cierre